### PR TITLE
Build and publish versioned docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,56 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-push:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+    
+    permissions:
+      contents: read
+      packages: write
+    
+    env:
+      IMAGE_NAME: ${{ secrets.IMAGE_NAME || 'aifoundryorg/storage-manager' }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.REGISTRY_URL || 'docker.io' }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+      
+      - name: Log in to container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.REGISTRY_URL || 'docker.io' }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            COMMIT=${{ github.sha }}
+            BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
 FROM golang:1.24.0-alpine3.21 AS builder
 
+ARG VERSION=dev
+ARG COMMIT=none
+ARG BUILD_DATE=unknown
+
 WORKDIR /go/src/github.com/aifoundry-org/storage-manager
 COPY go.* ./
 RUN go mod download
 COPY . .
-RUN go build -o /go/bin/storage-manager
+RUN go build -ldflags="-X github.com/aifoundry-org/storage-manager/cmd.Version=${VERSION} -X github.com/aifoundry-org/storage-manager/cmd.Commit=${COMMIT} -X github.com/aifoundry-org/storage-manager/cmd.BuildDate=${BUILD_DATE}" -o /go/bin/storage-manager
 
 FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,26 @@
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+LDFLAGS := -ldflags "-X github.com/aifoundry-org/storage-manager/cmd.Version=$(VERSION) -X github.com/aifoundry-org/storage-manager/cmd.Commit=$(COMMIT) -X github.com/aifoundry-org/storage-manager/cmd.BuildDate=$(BUILD_DATE)"
+
 all: build
 
-BIN_DIR = bin
-STORAGE_MANAGER = $(BIN_DIR)/storage-manager
-IMAGE ?= ainekko/storage-manager
+BINDIR = bin
+STORAGE_MANAGER = $(BINDIR)/storage-manager
+IMAGE ?= aifoundryorg/storage-manager
 
 build: $(STORAGE_MANAGER)
 
 $(STORAGE_MANAGER): $(BINDIR)
-	go build -o $@ .
+	go build $(LDFLAGS) -o $@ .
 
 $(BINDIR):
 	@mkdir -p $@
 
 image:
-	docker build -t $(IMAGE) .
+	docker build \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg COMMIT=$(COMMIT) \
+		--build-arg BUILD_DATE=$(BUILD_DATE) \
+		-t $(IMAGE) .
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,7 @@ new components and deleting existing ones.
 
 Run with --help for more information.
 		`,
+		Version: GetVersionString(),
 		PersistentPreRunE: func(c *cobra.Command, args []string) error {
 			bindFlags(cmd, v)
 			logLevel := v.GetInt("verbose")

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"fmt"
+)
+
+// Version information set by build flags
+var (
+	Version   = "dev"
+	Commit    = "none"
+	BuildDate = "unknown"
+)
+
+// GetVersionString returns a formatted version string
+func GetVersionString() string {
+	return fmt.Sprintf("Storage Manager %s (commit: %s, built: %s)", Version, Commit, BuildDate)
+}


### PR DESCRIPTION
This adds new github workflow that is triggered on version tag (v*) push and builds/pushes docker image.

Workflow needs the following repository (actions) secrets:

- IMAGE_NAME - defaults to `aifoundryorg/storage-manager`
- REGISTRY_URL - defaults to `docker.io`
- REGISTRY_USERNAME
- REGISTRY_TOKEN

Binary is versioned after git tag at build time.
Check with `--version` flag.