### PR TITLE
Use docker hub specific workflow secrets

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,7 +28,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ secrets.REGISTRY_URL || 'docker.io' }}/${{ env.IMAGE_NAME }}
+          images: docker.io/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -37,9 +37,9 @@ jobs:
       - name: Log in to container registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ secrets.REGISTRY_URL || 'docker.io' }}
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          registry: docker.io
+          username: ${{ secrets.DH_REGISTRY_USERNAME }}
+          password: ${{ secrets.DH_REGISTRY_TOKEN }}
       
       - name: Build and push Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
Use `DH_REGISTRY_USERNAME` and `DH_REGISTRY_TOKEN` secrets.

Retire `REGISTRY_URL` secret and always use `docker.io`.